### PR TITLE
Add redirect to success page

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -41,9 +41,9 @@ class PurchasesController < ApplicationController
       @billing_address.save
       @shipping_address.save
 
-      render json: "success!"
+      redirect_to '/success'
     else
-      render json: "fail!"
+      render json: 'An error has occurred. Please go back and try again.'
     end
   end
 

--- a/app/views/products/success.html.erb
+++ b/app/views/products/success.html.erb
@@ -1,0 +1,1 @@
+This is the success page!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root :to =>'mcsubscribe#launch'
   get 'mcsubscribe/launch'
 
+  get 'success', to: 'products#success'
+
   resources :products, only: [:index, :show]
   resources :purchases, only: [:new, :create]
 end


### PR DESCRIPTION
To find the success page, look in views/products/ for success.html.erb.
There's a route for it that points to products#success, so the url can
just be /success. That's where it redirects in the controller.

If it fails, there's no redirect. The page currently renders a json
error message, but that can be changed.
